### PR TITLE
Couple of small fixes

### DIFF
--- a/src/org/transmart/tm2cbio/Translator.groovy
+++ b/src/org/transmart/tm2cbio/Translator.groovy
@@ -58,9 +58,13 @@ case_list_ids: ${cases.join('\t')}
 cancer_study_identifier: ${c.study_id}
 name: ${c.study_name}
 description: ${c.study_description}
-short_name: ${c.study_short_name}
-citation: ${c.study_citation}
-pmid: ${c.study_pmid}""")
+short_name: ${c.study_short_name}""")
+        if(!c.study_citation==null) {
+            metastudy.write("""citation:${c.study_citation }""")
+        }
+        if(!c.study_pmid==null) {
+            metastudy.write("""pmid: ${c.study_pmid}""")
+        }
     }
 
 

--- a/src/org/transmart/tm2cbio/datatypes/expression/ExpressionTranslator.groovy
+++ b/src/org/transmart/tm2cbio/datatypes/expression/ExpressionTranslator.groovy
@@ -15,7 +15,7 @@ class ExpressionTranslator extends AbstractTranslator {
     //magic stable ids for data type
     def datatype2StableId = ['CONTINUOUS':'mrna', 'Z-SCORE':'mrna_median_Zscores', 'DISCRETE':'mrna_outliers']
     //mapping column name as defined in config file to the datatype
-    def datacol2datatype = ['LOG2E':'CONTINUOUS', 'Z-SCORE':'Z-SCORE']
+    def datacol2datatype = ['LOG2E':'CONTINUOUS', 'Z-SCORE':'Z-SCORE', 'ZSCORE':'Z-SCORE']
 
     def samplesPerGene = [:]
     def entrezIdsPerHugo = [:]
@@ -29,6 +29,7 @@ class ExpressionTranslator extends AbstractTranslator {
             typeConfig.profile_name = "$c.study_name Expression data"
         def datatype = datacol2datatype[typeConfig.data_column]
         def meta = new File(typeConfig.getMetaFilename(c));
+        def showInAnalysisTab = datatype.equalsIgnoreCase("Z-SCORE")?true:false;
         meta.write("""cancer_study_identifier: ${c.study_id}
 genetic_alteration_type: MRNA_EXPRESSION
 datatype: ${datatype}
@@ -36,7 +37,7 @@ stable_id: ${datatype2StableId[datatype]}
 profile_name: ${typeConfig.profile_name}
 profile_description: ${typeConfig.profile_description} for ${c.patient_count} patients.
 data_filename: ${typeConfig.getDataFilenameOnly(c)}
-show_profile_in_analysis_tab: true
+show_profile_in_analysis_tab: ${showInAnalysisTab}
 """)
     }
 

--- a/src/org/transmart/tm2cbio/utils/Converter.groovy
+++ b/src/org/transmart/tm2cbio/utils/Converter.groovy
@@ -5,7 +5,7 @@ package org.transmart.tm2cbio.utils
  */
 class Converter {
     private static String conversionImpl(String s, groovy.lang.Closure<Double> c) {
-        if (s.startsWith("NA"))
+        if (s.startsWith("NA") || s.equalsIgnoreCase(""))
             return "NA"
         double days = parseEuropeanDouble(s)
         return c.call(days).intValue().toString()


### PR DESCRIPTION
Added ZSCORE as an acceptable datacolumn
Show profile in analysis tab now only true for Z-SCORE

 Clinical:
 When converting e.g. days2months, an empty value now also return NA

 Study:
 pmedid and citation no longer written to meta file as null, preventing an error in the new cbio version (1.3.1)