### PR TITLE
Clinical display name and description underscores

### DIFF
--- a/src/org/transmart/tm2cbio/datatypes/clinical/ClinicalTranslator.groovy
+++ b/src/org/transmart/tm2cbio/datatypes/clinical/ClinicalTranslator.groovy
@@ -192,12 +192,14 @@ data_filename: ${getSampleFileName(typeConfig.getDataFilenameOnly(c))}
     private void writeMeta(Writer out, Map concept2col, List<String> columns) {
         //write meta information
         out.println("#" + columns.collect({
-            concept2col[it]
+            concept2col[it].replace("_", " ")
         }).join('\t'));
-        out.println("#" + columns.join('\t'));
+        out.println("#" + columns.collect({
+            it.replace("_", " ")
+        }).join('\t'))
         out.println("#" + columns.collect({
             getTypeForConcept(it)
-        }).join('\t'));
+        }).join('\t'))
         out.println("#" + columns.collect({
             "5" //for priority
         }).join('\t'))
@@ -205,6 +207,7 @@ data_filename: ${getSampleFileName(typeConfig.getDataFilenameOnly(c))}
             concept2col[it]
         }).join('\t'))
     }
+
 
     private String getTypeForConcept(String it) {
         if (typeConfig.types.containsKey(it))

--- a/src/org/transmart/tm2cbio/datatypes/clinical/ClinicalTranslator.groovy
+++ b/src/org/transmart/tm2cbio/datatypes/clinical/ClinicalTranslator.groovy
@@ -273,7 +273,7 @@ data_filename: ${getSampleFileName(typeConfig.getDataFilenameOnly(c))}
                             uniqueTerms.push(terms[j])
                     //always keep the leaf
                     uniqueTerms.push(terms.last())
-                    concept2col[conceptsInCollision[i]] = uniqueTerms.join('_')
+                    concept2col[conceptsInCollision[i]] = uniqueTerms.join(' ')
                 })
             }
         }


### PR DESCRIPTION
New cbio actually shows the clinical attribute underscores (description and display name), so replaced the underscores with spaces